### PR TITLE
fix: update ingress-nginx version to 4.12.1 (nginx version is 1.12.1) to address security vulnerability CVE-2025-1098

### DIFF
--- a/deploy/helmfile.yaml
+++ b/deploy/helmfile.yaml
@@ -17,6 +17,8 @@ releases:
       app: ingress-nginx
     wait: true
     chart: ingress-nginx/ingress-nginx
+    // update ingress-nginx version to 1.12.1 for fix CVE-2025-1098
+    // https://www.opennet.ru/opennews/art.shtml?num=62946
     version: 4.12.1
     values:
       - values-ingress-nginx.yaml.gotmpl

--- a/deploy/helmfile.yaml
+++ b/deploy/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
     wait: true
     chart: ingress-nginx/ingress-nginx
     # update ingress-nginx version to 1.12.1 for fix CVE-2025-1098
-    // https://www.opennet.ru/opennews/art.shtml?num=62946
+    # https://www.opennet.ru/opennews/art.shtml?num=62946
     version: 4.12.1
     values:
       - values-ingress-nginx.yaml.gotmpl

--- a/deploy/helmfile.yaml
+++ b/deploy/helmfile.yaml
@@ -17,7 +17,7 @@ releases:
       app: ingress-nginx
     wait: true
     chart: ingress-nginx/ingress-nginx
-    version: 4.10.1
+    version: 4.12.1
     values:
       - values-ingress-nginx.yaml.gotmpl
 

--- a/deploy/helmfile.yaml
+++ b/deploy/helmfile.yaml
@@ -17,7 +17,7 @@ releases:
       app: ingress-nginx
     wait: true
     chart: ingress-nginx/ingress-nginx
-    // update ingress-nginx version to 1.12.1 for fix CVE-2025-1098
+    # update ingress-nginx version to 1.12.1 for fix CVE-2025-1098
     // https://www.opennet.ru/opennews/art.shtml?num=62946
     version: 4.12.1
     values:


### PR DESCRIPTION
In version 1.12.1 was fixed IngressNightmare vulnerability